### PR TITLE
Changes to create_log_lam_grid were not backwards compatible

### DIFF
--- a/Starfish/grid_tools.py
+++ b/Starfish/grid_tools.py
@@ -1079,7 +1079,7 @@ class Instrument:
         self.oversampling = oversampling
         self.wl_range = wl_range
 
-        self.wl_dict = create_log_lam_grid(self.FWHM/self.oversampling, *self.wl_range)
+        self.wl_dict = create_log_lam_grid(*self.wl_range, min_vc=self.FWHM/(self.oversampling * C.c_kms))
         #Take the starting and ending wavelength ranges, the FWHM,
         # and oversampling value and generate an outwl grid  that can be resampled to.
 

--- a/Starfish/grid_tools.py
+++ b/Starfish/grid_tools.py
@@ -611,7 +611,7 @@ class HDF5Creator:
         # Create the final wavelength grid, onto which we will interpolate the
         # Fourier filtered wavelengths
         # an upper limit on the final dv
-        dv_temp = self.Instrument.FWHM/self.Instrument.oversampling/C.c_kms
+        dv_temp = self.Instrument.FWHM/self.Instrument.oversampling
         wl_dict = create_log_lam_grid(dv_temp, wl_min, wl_max)
         self.wl_final = wl_dict["wl"]
         self.dv_final = calculate_dv_dict(wl_dict)

--- a/Starfish/grid_tools.py
+++ b/Starfish/grid_tools.py
@@ -1079,7 +1079,7 @@ class Instrument:
         self.oversampling = oversampling
         self.wl_range = wl_range
 
-        self.wl_dict = create_log_lam_grid(*self.wl_range, min_vc=self.FWHM/(self.oversampling * C.c_kms))
+        self.wl_dict = create_log_lam_grid(self.FWHM/self.oversampling, *self.wl_range)
         #Take the starting and ending wavelength ranges, the FWHM,
         # and oversampling value and generate an outwl grid  that can be resampled to.
 

--- a/Starfish/spectrum.py
+++ b/Starfish/spectrum.py
@@ -24,7 +24,7 @@ def calculate_dv(wl):
 
     :returns: (float) delta-v in units of km/s
     '''
-    return C.c_kms * np.min(np.diff(wl)/wl[:-1])
+    return C.c_kms * np.minimum(np.diff(wl)/wl[:-1])
 
 def calculate_dv_dict(wl_dict):
     '''

--- a/Starfish/spectrum.py
+++ b/Starfish/spectrum.py
@@ -73,9 +73,6 @@ def create_log_lam_grid(dv=1., wl_start=3000., wl_end=13000., min_vc=None):
 
     CDELT1 = (CRVALN - CRVAL1) / (NAXIS1 - 1)
 
-    print(min_vc)
-    print(CDELT_temp)
-    print(NAXIS1)
     p = np.arange(NAXIS1)
     wl = 10 ** (CRVAL1 + CDELT1 * p)
     return {"wl": wl, "CRVAL1": CRVAL1, "CDELT1": CDELT1, "NAXIS1": NAXIS1}

--- a/Starfish/spectrum.py
+++ b/Starfish/spectrum.py
@@ -37,7 +37,7 @@ def calculate_dv_dict(wl_dict):
     dv = C.c_kms * (10**CDELT1 - 1)
     return dv
 
-def create_log_lam_grid(dv, wl_start=3000., wl_end=13000.):
+def create_log_lam_grid(dv=1., wl_start=3000., wl_end=13000., min_vc=None):
     '''
     Create a log lambda spaced grid with ``N_points`` equal to a power of 2 for
     ease of FFT.
@@ -50,6 +50,8 @@ def create_log_lam_grid(dv, wl_start=3000., wl_end=13000.):
     :type min_wl: (delta_wl, wl)
     :param dv: maximum bounds on the velocity spacing (in km/s)
     :type dv: float
+    :param min_vc: tightest spacing. Overrides dv if given!
+-   :type min_vc: float
 
     :returns: a wavelength dictionary containing the specified properties. Note
         that the returned dv will be <= specified dv.
@@ -58,7 +60,10 @@ def create_log_lam_grid(dv, wl_start=3000., wl_end=13000.):
     '''
     assert wl_start < wl_end, "wl_start must be smaller than wl_end"
 
-    CDELT_temp = np.log10(dv/C.c_kms + 1.)
+    if min_vc is None:
+        min_vc = dv/C.c_kms
+
+    CDELT_temp = np.log10(min_vc + 1.)
     CRVAL1 = np.log10(wl_start)
     CRVALN = np.log10(wl_end)
     N = (CRVALN - CRVAL1) / CDELT_temp
@@ -68,6 +73,9 @@ def create_log_lam_grid(dv, wl_start=3000., wl_end=13000.):
 
     CDELT1 = (CRVALN - CRVAL1) / (NAXIS1 - 1)
 
+    print(min_vc)
+    print(CDELT_temp)
+    print(NAXIS1)
     p = np.arange(NAXIS1)
     wl = 10 ** (CRVAL1 + CDELT1 * p)
     return {"wl": wl, "CRVAL1": CRVAL1, "CDELT1": CDELT1, "NAXIS1": NAXIS1}

--- a/Starfish/spectrum.py
+++ b/Starfish/spectrum.py
@@ -24,7 +24,7 @@ def calculate_dv(wl):
 
     :returns: (float) delta-v in units of km/s
     '''
-    return C.c_kms * np.minimum(np.diff(wl)/wl[:-1])
+    return C.c_kms * np.min(np.diff(wl)/wl[:-1])
 
 def calculate_dv_dict(wl_dict):
     '''


### PR DESCRIPTION
I think you made some recent changes to grid_tools and spectrum that broke some things. There were still a few calls to create_log_lam_grid that expected a min_vc keyword. I made dv optional, and put the min_vc keyword back in. min_vc overrides dv if it is given.

The call in HDF5Creator was also dividing dv by c, which create_log_lam_grid already does.