### PR TITLE
Experiment to try to get the Travis builds to stop failing: miniconda update.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,20 +20,19 @@ matrix:
           env: NUMPY_VERSION=1.8
 
 before_install:
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - conda update --yes conda
+    - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update --q conda
+    - conda info -a
 
 install:
     - sudo apt-get install -qq
-
     - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
     - source activate test
-
     - conda install --yes numpy=$NUMPY_VERSION scipy matplotlib Cython h5py scikit-learn astropy pyyaml pytest
-
     - python setup.py build_ext --inplace
 
 script:


### PR DESCRIPTION
I'm pretty sure I traced the problem back to the `.travis.yml` file using the wrong miniconda version.  So I updated the `.travis.yml` file with the most recent recommendation for [how to use conda with Travis CI](http://conda.pydata.org/docs/travis.html).  I basically copied their recommendations verbatim into the `before_install` section.  This change got the tests passing for me.

By the way, Jake Vanderplas figured out [how to cache conda dependencies](https://github.com/uwescience/shablona/blame/master/.travis.yml) between Travis builds.  That could be useful for best practices.  But I did not bother to add that functionality here.  