### PR TITLE
Add support for incrementally saving progress of long MCMC chains 

### DIFF
--- a/Starfish/parallel.py
+++ b/Starfish/parallel.py
@@ -17,6 +17,7 @@ parser.add_argument("--initPhi", action="store_true", help="Create *phi.json fil
 parser.add_argument("--optimize", choices=["Theta", "Phi", "Cheb"], help="Optimize the Theta or Phi parameters, keeping the alternate set of parameters fixed.")
 parser.add_argument("--sample", choices=["ThetaCheb", "ThetaPhi", "ThetaPhiLines"], help="Sample the parameters, keeping the alternate set of parameters fixed.")
 parser.add_argument("--samples", type=int, default=5, help="How many samples to run?")
+parser.add_argument("--incremental_save", type=int, default=0, help="How often to save incremental progress of MCMC samples.")
 args = parser.parse_args()
 
 from multiprocessing import Process, Pipe

--- a/Starfish/samplers.py
+++ b/Starfish/samplers.py
@@ -72,7 +72,7 @@ class StateSampler(Sampler):
         self._lnprob = np.empty(0)
 
     def sample(self, p0, lnprob0=None, randomstate=None, thin=1,
-               storechain=True, iterations=1, **kwargs):
+               storechain=True, iterations=1, incremental_save=0, **kwargs):
         """
         Advances the chain ``iterations`` steps as an iterator
 
@@ -174,6 +174,11 @@ class StateSampler(Sampler):
                 ind = i0 + int(i / thin)
                 self._chain[ind, :] = p
                 self._lnprob[ind] = lnprob0
+
+            # The default of 0 evaluates to False
+            if incremental_save:
+                if (((i+1) % incremental_save) == 0) & (i > 0): 
+                    np.save('chain_backup.npy', self._chain)
 
             # Heavy duty iterator action going on right here...
             yield p, lnprob0, self.random_state

--- a/scripts/star.py
+++ b/scripts/star.py
@@ -199,7 +199,7 @@ if args.sample == "ThetaCheb" or args.sample == "ThetaPhi" or args.sample == "Th
 
     sampler = StateSampler(lnprob, p0, cov, query_lnprob=query_lnprob, acceptfn=acceptfn, rejectfn=rejectfn, debug=True, outdir=Starfish.routdir)
 
-    p, lnprob, state = sampler.run_mcmc(p0, N=args.samples)
+    p, lnprob, state = sampler.run_mcmc(p0, N=args.samples, incremental_save=args.incremental_save)
     print("Final", p)
 
     sampler.write()


### PR DESCRIPTION
This PR provides a possible solution to feature request Issue #40- the ability to incrementally save progress in an MCMC chain.  


- I added a commandline argument `--incremental_save`, which is called from `star.py`.
- This commandline argument takes an integer, N, and saves the complete MCMC chain after every N iterations.
- The default is **zero**, which means **no** incremental saving is performed.  This choice yields no change in the existing behavior if the commandline argument is absent.
- As it stands, the backup will only save the Theta chains, not the nuisance parameters.  
- It saves as a `.npy` file.

Possible drawbacks:
- There is no support for thinning or burning.
- Saving the nuisance parameter chains would require a different solution.  
- What to name the file: "chain_backup.npy" is not streamlined with `mc.hdf5` and `walkers.png`.  Perhaps "mc_backup.npy" is a better fit?  Or simply "mc.npy".

A side benefit of this feature is that it provides a simple backup in case hdf5 files fail catastrophically, as mentioned in Issue #24.