### PR TITLE
Fix for Issue #51- misplaced argparser dependency in estimate_cov

### DIFF
--- a/Starfish/utils.py
+++ b/Starfish/utils.py
@@ -286,12 +286,12 @@ def plot_walkers(flatchain, base, start=0, end=-1, labels=None):
     fig.savefig(base + "walkers.png")
     plt.close(fig)
 
-def estimate_covariance(flatchain, base):
+def estimate_covariance(flatchain, base, ndim=0):
 
-    if args.ndim:
-        d = args.ndim
-    else:
+    if ndim == 0:
         d = flatchain.shape[1]
+    else:
+        d = ndim
 
     import matplotlib.pyplot as plt
 
@@ -322,10 +322,6 @@ def estimate_covariance(flatchain, base):
     print(std_dev)
 
     print("'Optimal' jumps")
-    if args.ndim:
-        d = args.ndim
-    else:
-        d = flatchain.shape[1]
     print(2.38/np.sqrt(d) * std_dev)
 
     np.save(base + "opt_jump.npy", opt_jump)

--- a/scripts/chain.py
+++ b/scripts/chain.py
@@ -25,7 +25,7 @@ parser.add_argument("--acor", action="store_true", help="Calculate the autocorre
 parser.add_argument("--acor-window", type=int, default=50, help="window to compute acor with")
 
 parser.add_argument("--cov", action="store_true", help="Estimate the covariance between two parameters.")
-parser.add_argument("--ndim", type=int, help="How many dimensions to use for estimating the 'optimal jump'.")
+parser.add_argument("--ndim", type=int, default=0, help="How many dimensions to use for estimating the 'optimal jump'.")
 parser.add_argument("--paper", action="store_true", help="Change the figure plotting options appropriate for the paper.")
 
 args = parser.parse_args()
@@ -89,7 +89,7 @@ if args.paper:
 
 if args.cov:
     assert len(flatchainList) == 1, "If estimating covariance, only specify one flatchain"
-    utils.estimate_covariance(flatchainList[0], base=args.outdir)
+    utils.estimate_covariance(flatchainList[0], base=args.outdir, ndim=args.ndim)
 
 if args.gelman:
     assert len(flatchainList) > 1, "If running Gelman-Rubin test, must provide more than one flatchain"


### PR DESCRIPTION
See Issue #51.  This PR removes the errant argparser in utils.py, and still achieves the desired default behavior: measure covariance over all dimensions.