### PR TITLE
Add a binary --use_cov commandline argument for star.py

### DIFF
--- a/Starfish/parallel.py
+++ b/Starfish/parallel.py
@@ -18,6 +18,7 @@ parser.add_argument("--optimize", choices=["Theta", "Phi", "Cheb"], help="Optimi
 parser.add_argument("--sample", choices=["ThetaCheb", "ThetaPhi", "ThetaPhiLines"], help="Sample the parameters, keeping the alternate set of parameters fixed.")
 parser.add_argument("--samples", type=int, default=5, help="How many samples to run?")
 parser.add_argument("--incremental_save", type=int, default=0, help="How often to save incremental progress of MCMC samples.")
+parser.add_argument("--use_cov", action="store_true", help="Use the local optimal jump matrix if present.")
 args = parser.parse_args()
 
 from multiprocessing import Process, Pipe

--- a/scripts/star.py
+++ b/scripts/star.py
@@ -197,6 +197,13 @@ if args.sample == "ThetaCheb" or args.sample == "ThetaPhi" or args.sample == "Th
     jump = Starfish.config["Theta_jump"]
     cov = np.diag(np.array(jump["grid"] + [jump["vz"], jump["vsini"], jump["logOmega"]])**2)
 
+    if args.use_cov:
+        try:
+            cov = np.load('opt_jump.npy')
+            print("Found a local optimal jump matrix.")
+        except FileNotFoundError:
+            print("No optimal jump matrix found, using diagonal jump matrix.")
+
     sampler = StateSampler(lnprob, p0, cov, query_lnprob=query_lnprob, acceptfn=acceptfn, rejectfn=rejectfn, debug=True, outdir=Starfish.routdir)
 
     p, lnprob, state = sampler.run_mcmc(p0, N=args.samples, incremental_save=args.incremental_save)


### PR DESCRIPTION
This PR is one of several possible fixes for Issue #31, tuning the optimal jump size.

The existing code in `estimate_covariance()` already computes the optimal jumps, based on the technique described in "Efficient Metropolis Jumping Rules" (Gelman, Roberts, & Gilk 1996):
http://www.stat.columbia.edu/~gelman/research/published/baystat5.pdf

So this pull request just makes it easy to use the output of `chain.py ... --cov` by using the opt_jumps.npy file if it exists, and if it doesn't exist it defaults back to the diagonal matrix comprised of the jumps specified in the `config.yaml` file.

The command line solution seemed fair.  An alternative would be to put a `use_cov` flag in the `config.yaml` file.  Six of one, half dozen of the other.