### PR TITLE
Resolves issue #15: fix_c0 is handled in ChebyshevSpectrum

### DIFF
--- a/Starfish/parallel.py
+++ b/Starfish/parallel.py
@@ -462,14 +462,12 @@ class Order:
         optimize the Chebyshev parameters
         '''
 
-        # self.fix_c0 = True if index == (len(DataSpectrum.wls) - 1) else False #Fix the last c0
-        # This is necessary if we want to update just a single order.
-
-        if self.chebyshevSpectrum.fix_c0 & (len(self.dataSpectrum.wls) > 1):
+        if self.chebyshevSpectrum.fix_c0:
             p0 = np.zeros((self.npoly - 1))
+            self.fix_c0 = True
         else:
-            self.chebyshevSpectrum.fix_c0 = False
             p0 = np.zeros((self.npoly))
+            self.fix_c0 = False
 
         def fprob(p):
             self.chebyshevSpectrum.update(p)


### PR DESCRIPTION
This PR should (re-)close Issue #15.  Here's what was happening:

`ChebyshevSpectrum` in `spectrum.py`  already handles the case of single spectral orders requiring `fix_c0 = True`, and the case of multiple orders requiring *one* of the orders to have `fix_c0 = True`.  So the `optimize_Cheb` function did not need to redo the checking.  But `optimize_Cheb` *does* need to put `self.chebyshevSpectrum.fix_c0` into `self.fix_c0`.  As it stood, the code did not accomplish the second task in the case of a single spectral order.  So this code should fix it.

I figured this all out by printing the values of `self.chebyshevSpectrum.fix_c0` before and after the conditionals, for both single- and multiple- order scenarios.  I also spot checked the value of `fix_c0` in the `*phi.json` files for both scenarios.  Before this bug-fix the value of `fix_c0` was incorrectly *false* in the single order case.  After this bug-fix the `fix_c0` term is now correctly *true*.

Note that the code assumes you are not changing the **orders:** keyword in your config.yaml file after making your `*phi.json` files.  If you change the final order of the **orders:** keyword, then you have to redo your optimization.  This makes sense, and is the desired behavior.