### PR TITLE
import triangle with its new name, corner

### DIFF
--- a/scripts/pca.py
+++ b/scripts/pca.py
@@ -233,7 +233,10 @@ if args.plot == "emcee":
     #Make a triangle plot of the samples
     my_pca = emulator.PCAGrid.open()
     flatchain = np.load("eparams_emcee.npy")
-    import triangle
+    try:
+        import corner as triangle
+    except:
+        import triangle
 
     # figure out how many separate triangle plots we need to make
     npar = len(Starfish.parname) + 1


### PR DESCRIPTION
Tries to import corner as triangle first, and if that fails, reverts to importing triangle via its old name.
(Note: this package is not currently listed as a dependency, and probably should be!)