### PR TITLE
pca.py make plotting directory if it does not exist

### DIFF
--- a/scripts/pca.py
+++ b/scripts/pca.py
@@ -34,6 +34,10 @@ if args.create:
     my_pca = PCAGrid.create(myHDF5)
     my_pca.write()
 
+# Create plotting directory if not already created
+if args.plot and not os.path.isdir(Starfish.config['plotdir']):
+    os.makedirs(Starfish.config['plotdir'])
+    
 if args.plot == "reconstruct":
     my_HDF5 = HDF5Interface()
     my_pca = PCAGrid.open()


### PR DESCRIPTION
I noticed while going through the documentation example for WASP14 that the `pca.py` scripts will fail when you try plotting if you haven't manually `mkdir` the plotting directory as defined in `config.yaml`. I've added two lines that will create the plotting directory (recursively, if necessary) into the `pca.py` script. This will only run if `--plot` argument is set.

I have not tested this trivial change.