### PR TITLE
Platform dependent extra_compile_args.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,19 @@
 import sys
 from setuptools import setup, Extension
 import builtins
+import platform
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+if platform.system() == "Windows":
+    extra_compile_args = []  # No compile args needed on Windows
+else:
+    extra_compile_args=["-Wno-declaration-after-statement",
+                        "-Wno-error=declaration-after-statement",
+                        "-Wno-unused-function",
+                        "-Wno-unused-variable",
+                        "-Wno-unused-but-set-variable"]
 
 try:
     from Cython.Distutils import build_ext
@@ -12,19 +22,11 @@ except ImportError:
 
     ext_modules = [Extension("Starfish.covariance",
                              sources=["Starfish/covariance.c"],
-                             extra_compile_args=["-Wno-declaration-after-statement",
-                                                 "-Wno-error=declaration-after-statement",
-                                                 "-Wno-unused-function",
-                                                 "-Wno-unused-variable",
-                                                 "-Wno-unused-but-set-variable"]), ]
+                             extra_compile_args=extra_compile_args), ]
 else:
     ext_modules = [Extension("Starfish.covariance",
                              sources=["Starfish/covariance.pyx"],
-                             extra_compile_args=["-Wno-declaration-after-statement",
-                                                 "-Wno-error=declaration-after-statement",
-                                                 "-Wno-unused-function",
-                                                 "-Wno-unused-variable",
-                                                 "-Wno-unused-but-set-variable"]), ]
+                             extra_compile_args=extra_compile_args), ]
 
 if sys.version < '3.5.2':
     raise RuntimeError('Error: Python 3.6 or greater required for Starfish (using {})'.format(sys.version))


### PR DESCRIPTION
This removes the compile args for a install on windows. 

I have tested pip installing this branch successfully with appveyor [here](https://ci.appveyor.com/project/jason-neal/eniric/build/job/9wpktjph3pik4hxy)

I see in #87 @mileslucas works on a windows machine, how did you get around the compile arg issues. I have it on my windows tablet and on appveyor  e.g. [here](https://ci.appveyor.com/project/jason-neal/eniric/builds/20979710/job/kw4rxxusm5wt2lrf)

```
Command "C:\Python36\python.exe -u -c "import setuptools, tokenize;__file__='C:\\Users\\appveyor\\AppData\\Local\\Temp\\1\\pip-install-k56ib4ut\\Starfish\\setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record C:\Users\appveyor\AppData\Local\Temp\1\pip-record-7fltmuk4\install-record.txt --single-version-externally-managed --compile" failed with error code 1 in C:\Users\appveyor\AppData\Local\Temp\1\pip-install-k56ib4ut\Starfish\
Command exited with code 1
```

I wonder what is different for you if. you do not get these errors.