### PR TITLE
chebyshev correction for SpectrumModel

### DIFF
--- a/Starfish/models/spectrum_model.py
+++ b/Starfish/models/spectrum_model.py
@@ -151,7 +151,6 @@ class SpectrumModel:
         self.grid_params = grid_params
 
         self._lnprob = None
-        self._cheb = None
         self._glob_cov = None
         self._loc_cov = None
 
@@ -265,7 +264,9 @@ class SpectrumModel:
             fluxes = extinct(self.data.wave, fluxes, self.params["Av"])
 
         if "cheb" in self.params:
-            fluxes = chebyshev_correct(self.data.wave, fluxes, self.cheb)
+            # force linear term to be 1 to avoid degeneracy with log_scale
+            coeffs = [1, *self.cheb]
+            fluxes = chebyshev_correct(self.data.wave, fluxes, coeffs)
 
         # Only rescale flux_mean and flux_std
         if "log_scale" in self.params:


### PR DESCRIPTION
This PR adds functionality within `SpectrumModel` for doing Chebyshev correction. I've decided that the coefficients will start from the 2nd term, since the 1st (linear) chebyshev coefficient is fully degenerate with `log_scale`. This means if you specify `cheb=[0.1, 0.1]` the full chebyshev coefficients used are `[1, 0.1, 0.1]`

General usage will look like:
```python
# add via constructor
model = SpectrumModel(..., cheb=[0.1, 0.1])
# add using flatterdict keys
model["cheb"] = [-0.2, 0.1]
model["cheb:0"] = 0
# equivalently using properties, more for internal usage
model.cheb = ...
```

Currently this is working in terms of instantiation and evaluating/correcting the fluxes, but there is a bug related to the inner parameter data structure that doesn't allow the `model["cheb:0"] = X` syntax (https://github.com/gmr/flatdict/issues/44). This means the whole `set_param_dict` interface is broken, so we can't train the model.

Once that bug is resolved, what's left should just be some unit-testing and making sure the docs are up to date.
